### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,15 @@ language: php
 php:
   - 7.0
   - 7.1
+  - 7.2
+  - 7.3
 
 before_script:
   - composer self-update
   - composer install --no-interaction --prefer-source
-  - wget https://phar.phpunit.de/phpunit.phar
 
 script:
-  - php phpunit.phar
+  - vendor/bin/phpunit
 
 after_success:
   - wget https://scrutinizer-ci.com/ocular.phar

--- a/composer.json
+++ b/composer.json
@@ -21,10 +21,18 @@
       "SebastianFeldmann\\Crontab\\": "src/"
     }
   },
+  "autoload-dev": {
+    "psr-4": {
+      "SebastianFeldmann\\Crontab\\": "tests/"
+    }
+  },
   "require": {
     "php": ">=7.0.0",
     "ext-spl": "*",
     "sebastianfeldmann/cli": "~1.0"
+  },
+  "require-dev": {
+    "phpunit/phpunit": "^6.5 || ^7.0"
   },
   "extra": {
     "branch-alias": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -13,14 +13,9 @@
   <logging>
     <log type="coverage-html"
          target="build/coverage"
-         title="sebastianfeldmann\crontab"
-         charset="UTF-8"
-         yui="true"
-         highlight="true"
          lowUpperBound="35"
          highLowerBound="70" />
     <log type="junit"
-         target="build/logs/junit.xml"
-         logIncompleteSkipped="false" />
+         target="build/logs/junit.xml" />
   </logging>
 </phpunit>

--- a/tests/crontab/Cli/ExecutableTest.php
+++ b/tests/crontab/Cli/ExecutableTest.php
@@ -10,13 +10,14 @@
 namespace SebastianFeldmann\Crontab\Cli;
 
 use SebastianFeldmann\Crontab\Job;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class ExecutableTest
  *
  * @package SebastianFeldmann\Crontab
  */
-class ExecutableTest extends \PHPUnit\Framework\TestCase
+class ExecutableTest extends TestCase
 {
     /**
      * Tests Executable::createCommandLine

--- a/tests/crontab/JobTest.php
+++ b/tests/crontab/JobTest.php
@@ -9,12 +9,14 @@
  */
 namespace SebastianFeldmann\Crontab;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Class JobTest
  *
  * @package SebastianFeldmann\Crontab
  */
-class JobTest extends \PHPUnit\Framework\TestCase
+class JobTest extends TestCase
 {
     /**
      * Tests Job::getSchedule

--- a/tests/crontab/OperatorTest.php
+++ b/tests/crontab/OperatorTest.php
@@ -9,12 +9,14 @@
  */
 namespace SebastianFeldmann\Crontab;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Class OperatorTest
  *
  * @package SebastianFeldmann\Crontab
  */
-class OperatorTest extends \PHPUnit\Framework\TestCase
+class OperatorTest extends TestCase
 {
     /**
      * Tests Operator::getJobs

--- a/tests/crontab/Output/ListFormatterTest.php
+++ b/tests/crontab/Output/ListFormatterTest.php
@@ -10,13 +10,14 @@
 namespace SebastianFeldmann\Crontab\Output;
 
 use SebastianFeldmann\Crontab\Parser\Vixie;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class ListFormatterTest
  *
  * @package SebastianFeldmann\Crontab
  */
-class ListFormatterTest extends \PHPUnit\Framework\TestCase
+class ListFormatterTest extends TestCase
 {
     /**
      * Tests ListFormatter::format
@@ -35,9 +36,9 @@ class ListFormatterTest extends \PHPUnit\Framework\TestCase
            '20 4 * * * echo 2',
         ]);
 
-        $this->assertEquals(2, count($formatted));
+        $this->assertCount(2, $formatted);
         $this->assertEquals('10 4 * * *', $formatted[0]->getSchedule());
         $this->assertEquals('echo 1', $formatted[0]->getCommand());
-        $this->assertEquals(2, count($formatted[0]->getComments()));
+        $this->assertCount(2, $formatted[0]->getComments());
     }
 }

--- a/tests/crontab/Parser/VixieTest.php
+++ b/tests/crontab/Parser/VixieTest.php
@@ -9,12 +9,14 @@
  */
 namespace SebastianFeldmann\Crontab\Parser;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Class ParserTest
  *
  * @package SebastianFeldmann\Crontab
  */
-class ParserTest extends \PHPUnit\Framework\TestCase
+class ParserTest extends TestCase
 {
     /**
      * Tests Vixie::parse


### PR DESCRIPTION
# Changed log
- Add `php-7.3` test in Travis CI build because this PHP version is stable.
- Remove downloading `phpunit` in Travis CI build and add `require-dev` block in `composer.json` to define the PHPUnit version.
- Add namespace for classes in `tests/` and define this in `autoload-dev` block.
- Remove invalid attribute settings in `phpunit.xml`.
- Using `use` syntax for `PHPUnit` namespace because of consistency.
- Using `assertCount` to assert whether the expected count number is same as actual array length.
