### PR TITLE
Drop PHP 7.0 and add PHP 7.4 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: php
 
 php:
-  - 7.0
   - 7.1
   - 7.2
   - 7.3
+  - 7.4
 
 before_script:
   - composer self-update

--- a/composer.json
+++ b/composer.json
@@ -27,12 +27,12 @@
     }
   },
   "require": {
-    "php": ">=7.0.0",
+    "php": ">=7.1.0",
     "ext-spl": "*",
     "sebastianfeldmann/cli": "~1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^6.5 || ^7.0"
+    "phpunit/phpunit": "^7.0"
   },
   "extra": {
     "branch-alias": {


### PR DESCRIPTION
# Changed log
- It seems that most of packages on [sebastianfeldmann](https://github.com/sebastianfeldmann) repositories require `php-7.1` version at least now.
I think it's time to let this package require `php-7.1` version at least now.
- Add `php-7.4` version support during Travis CI build.