### PR TITLE
PHP version requirement and GitHub action badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 
 [![Latest Stable Version](https://poser.pugx.org/sebastianfeldmann/crontab/v/stable.svg)](https://packagist.org/packages/sebastianfeldmann/crontab)
-[![Minimum PHP Version](https://img.shields.io/badge/php-%3E%3D%207.0-8892BF.svg)](https://php.net/)
+[![Minimum PHP Version](https://img.shields.io/badge/php-%3E%3D%207.1-8892BF.svg)](https://php.net/)
 [![Downloads](https://img.shields.io/packagist/dt/sebastianfeldmann/crontab.svg?v1)](https://packagist.org/packages/sebastianfeldmann/crontab)
 [![License](https://poser.pugx.org/sebastianfeldmann/crontab/license.svg)](https://packagist.org/packages/sebastianfeldmann/crontab)
-[![Build Status](https://travis-ci.org/sebastianfeldmann/crontab.svg?branch=master)](https://travis-ci.org/sebastianfeldmann/crontab)
+[![Build Status](https://github.com/sebastianfeldmann/git/workflows/CI-Build/badge.svg)](https://github.com/sebastianfeldmann/crontab/actions)
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/sebastianfeldmann/crontab/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/sebastianfeldmann/crontab/?branch=master)
 [![Code Coverage](https://scrutinizer-ci.com/g/sebastianfeldmann/crontab/badges/coverage.png?b=master)](https://scrutinizer-ci.com/g/sebastianfeldmann/crontab/?branch=master)
 
@@ -35,8 +35,8 @@ Installing *crontab* via Composer.
 ```php
 $crontab = new SebastianFeldmann\Crontab\Operator();
 foreach ($crontab->getJobs() as $job) {
-    echo "Description: . PHP_EOL . implode(PHP_EOL, $job->getComments()) . PHP_EOL;    
-    echo "Schedule: " . PHP_EOL . $job->getSchedule() . PHP_EOL;    
+    echo "Description: . PHP_EOL . implode(PHP_EOL, $job->getComments()) . PHP_EOL;
+    echo "Schedule: " . PHP_EOL . $job->getSchedule() . PHP_EOL;
     echo "Command: " . PHP_EOL . $job->getCommand() . PHP_EOL;
 }
 ```
@@ -59,7 +59,7 @@ This will add the following lines to your crontab.
 ```
 
 The crontab parser is looking for commands and their description in the lines above the command.
-The parser expects commands to **NOT** spread over multiple lines with \\.  
+The parser expects commands to **NOT** spread over multiple lines with \\.
 ```
 # Descriptoon for some command
 10 23 * * * some command


### PR DESCRIPTION
# Changed log
- It seems that the package requires `php-7.1` version at least.
It's time to modify the PHP version requirement badge.
- Using the GitHub Action badge to replace Travis CI build badge since switching Travis CI to GitHub actions.
- Removing unnecessary white space on `README`.